### PR TITLE
Begin setup of CI on GitHub Actions

### DIFF
--- a/.github/workflows/ptm-ci.yml
+++ b/.github/workflows/ptm-ci.yml
@@ -1,0 +1,45 @@
+name: ptm-ci
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  install-packages:
+    runs-on: ubuntu
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y make gfortran gcc g++
+        sudo apt-get install -y python3-pip
+        pip3 install numpy scipy matplotlib
+        pip3 install spacepy
+        pip freeze
+        gfortran --version
+    - name: Checkout
+      uses: actions/checkout@v2
+
+  build-ptm:
+    runs-on: ubuntu-18.04
+    needs: [install-packages]
+    steps:
+      - run: shopt -s expand_aliases
+      - run: alias python="python3"
+      - run: make
+      - run: ./ptm 1
+
+  test-dipole:
+    runs-on: ubuntu-18.04
+    needs: [install-packages]
+    steps:
+      - run: shopt -s expand_aliases
+      - run: alias python="python3"
+      - run: make
+      - run: python ptm_python/ptm_test_data.py


### PR DESCRIPTION
This one will take some testing, but I'm under the impression that it won't enable actions and test PR branches until there's an initial commit with a workflow...

So here's a workflow that probably won't work.
However, it sets up some basics:
- Run on Ubuntu-18.04 (same as the old docker container for CI)
- Trigger actions on push to master and PRs to master
- Installs packages following the old Docker container (with minor mods because I believe the GH Actions images already have some of the packages).

If this sets up the actions workflow then I can test the full workflow in a PR and force-push updates until it runs correctly...