### PR TITLE
Make Stormer cutoff and related robust to array input

### DIFF
--- a/ptm_python/test_ptm.py
+++ b/ptm_python/test_ptm.py
@@ -99,6 +99,36 @@ class toolsTests(unittest.TestCase):
         c_west = self.cstorm_2010.cutoff_at_L(l_val, 90, 270)
         self.assertLessEqual(c_west, c_east)
 
+    def test_Stormer_east_west_array(self):
+        '''Stormer cutoff should be lower for west than east and work with array input'''
+        l_val = [5, 6]
+        c_east = self.cstorm_2010.cutoff_at_L(l_val, 90, 90, as_energy=True)
+        c_west = self.cstorm_2010.cutoff_at_L(l_val, 90, 270, as_energy=True)
+        np.testing.assert_array_less(c_west, c_east)
+
+    def test_Stormer_all_array(self):
+        '''Stormer cutoff work with array/list input for all 3 vars'''
+        l_val = [5, 6]
+        zen = [90, 90]
+        azi = [90, 270]
+        c_east = self.cstorm_2010.cutoff_at_L(l_val[0], 90, 90, as_energy=True)
+        c_west = self.cstorm_2010.cutoff_at_L(l_val[1], 90, 270, as_energy=True)
+        indiv = np.array([c_east, c_west])
+        togeth = self.cstorm_2010.cutoff_at_L(l_val, zen, azi, as_energy=True)
+        np.testing.assert_array_almost_equal(indiv, togeth)
+
+    def test_Stormer_all_array(self):
+        '''Stormer cutoff work with array/list input for all 3 vars'''
+        l_val = [5, 6, 7]
+        zen = 90
+        azi = 270
+        c1 = self.cstorm_2010.cutoff_at_L(l_val[0], zen, azi, as_energy=True)
+        c2 = self.cstorm_2010.cutoff_at_L(l_val[1], zen, azi, as_energy=True)
+        c3 = self.cstorm_2010.cutoff_at_L(l_val[2], zen, azi, as_energy=True)
+        indiv = np.array([c1, c2, c3])
+        togeth = self.cstorm_2010.cutoff_at_L(l_val, zen, azi, as_energy=True)
+        np.testing.assert_array_almost_equal(indiv, togeth)
+
     def test_l_to_lati_roundtrip(self):
         '''dipole L to invariant lat should be reversible'''
         l_val = [1, 2, 4, 8]
@@ -106,6 +136,18 @@ class toolsTests(unittest.TestCase):
         pred_l = [ptt.l_from_invariant_latitude(il) for il in lati]
         np.testing.assert_array_almost_equal(l_val, pred_l)
 
+    def test_l_to_lati_roundtrip_array(self):
+        '''dipole L to invariant lat should be reversible'''
+        l_val = [1, 2, 4, 8]
+        lati = ptt.invariant_latitude_from_l(l_val)
+        pred_l = ptt.l_from_invariant_latitude(lati)
+        np.testing.assert_array_almost_equal(l_val, pred_l)
+
+    def test_Stormer_vertical_cutoff_list(self):
+        lvals = [2.5, 4, 6.6]
+        v_rig_1 = [self.vstorm_2010.cutoff_at_L(l_val, as_energy=True) for l_val in lvals]
+        v_rig_2 = self.vstorm_2010.cutoff_at_L(lvals, as_energy=True)
+        np.testing.assert_array_almost_equal(v_rig_1, v_rig_2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #7 

This PR adds tests to ensure that inputs to the `cutoff_at_L` methods, as well as the invariant latitude to L (and vice versa) transformation, function correctly with scalar, list, and array inputs. The code is updated to provide support for scalar, list, and array inputs for these.
The docstring has been updated to reflect changes.