### PR TITLE
Clean up array temporary creation using assumed shape arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ PYEXE = `which python3`
 PROG = ptm
 F90 = gfortran
 OPT = -ffree-form -ffree-line-length-none -std=f2008ts -fopenmp -O3
-# For debug with GNU compiler, use -g flag
-# OPT = -ffree-form -ffree-line-length-none -std=f2008ts -fopenmp -g
+# For debug with GNU compiler, use -g flag; for runtime checks use -fcheck
+# OPT = -ffree-form -ffree-line-length-none -std=f2008ts -fopenmp -g -fcheck=all
 
 SRCS := $(wildcard src/*.f90)
 OBJS := $(patsubst %.f90,%.o,$(SRCS))

--- a/src/fileio.f90
+++ b/src/fileio.f90
@@ -82,7 +82,7 @@ contains
   implicit none
 
   type(particle) :: myParticle
-  real(dp), dimension(8), intent(out) :: dataStore
+  real(dp), dimension(:), intent(out) :: dataStore
   real(dp), dimension(3) :: bvec, bhat, xpos, gradb, rvec
   real(dp), dimension(3,3) :: Bgrad
   real(dp) :: b0, upara, uperp, gam

--- a/src/finite_differences.f90
+++ b/src/finite_differences.f90
@@ -49,8 +49,8 @@ contains
 
   implicit none
 
-  real(dp), dimension(3) :: x
-  real(dp), dimension(3) :: f
+  real(dp), dimension(:) :: x
+  real(dp), dimension(:) :: f
   real(dp) :: A, B, p, q, dxp, dxm, dxtot, dfp, dfm, denom
   real(dp) :: der
   integer, intent(in) :: idx
@@ -105,8 +105,8 @@ contains
   !
   implicit none
 
-  real(dp), dimension(3), intent(in) :: x, y
-  real(dp), dimension(3,3), intent(in) :: f
+  real(dp), dimension(:), intent(in) :: x, y
+  real(dp), dimension(:,:), intent(in) :: f
   real(dp), dimension(3) :: temp  
   real(dp) :: der
   integer, intent(in) :: idx, idy
@@ -146,8 +146,8 @@ contains
   !
   implicit none
 
-  real(dp), intent(in), dimension(3) :: x, y, z
-  real(dp), intent(in), dimension(3,3,3) :: f
+  real(dp), intent(in), dimension(:) :: x, y, z
+  real(dp), intent(in), dimension(:,:,:) :: f
   real(dp), dimension(3) :: temp
   real(dp) :: der
   integer, intent(in) :: idx, idy, idz

--- a/src/interpolation.f90
+++ b/src/interpolation.f90
@@ -200,9 +200,9 @@ contains
   ! Calculate the interpolation coefficients for an interpolant object
   implicit none
   
-  real(dp), dimension(64) :: myCoeffs
+  real(dp), dimension(:) :: myCoeffs
   type(grid) :: myGrid
-  real(dp), dimension(2,2,2), intent(in) :: F,FX,FY,FZ,FXY,FXZ,FYZ,FXYZ
+  real(dp), dimension(:,:,:), intent(in) :: F,FX,FY,FZ,FXY,FXZ,FYZ,FXYZ
   real(dp), dimension(64) :: bbar
   integer :: ix, iy, iz, irow
        
@@ -243,7 +243,7 @@ contains
   ! the function by including the optional gradf vector.
   implicit none
 
-  real(dp), dimension(64) :: myCoeffs
+  real(dp), dimension(:) :: myCoeffs
   type(grid) :: myGrid
   real(dp), intent(in) :: x0, y0, z0
   real(dp), intent(out) :: f0


### PR DESCRIPTION
This PR uses assumed shape arrays to avoid array temporaries proliferating. On resource constrained systems this leads to segfaults as well as runtime warnings with fcheck on.

Basically, strided arrays are passed around to select subsets of the field, etc. and with assumed dimension arrays these are required to be simply contiguous, not strided. There are better ways to fix this that will take significant work, but this stops the warnings and hopefully the memory management issues for resource constrained folks.